### PR TITLE
#1 Update all resources to be fetched over https

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,12 +5,12 @@
         <title>Infographic of REDD+ and related international laws</title> 
         
         <link rel="stylesheet" href="recycle.css" type="text/css" media="screen">
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js" type="text/javascript" charset="utf-8"></script>
-        <script src="paper.js" type="text/javascript" charset="utf-8"></script>
-        <script src="http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.1.7/underscore-min.js" type="text/javascript" charset="utf-8"></script>
-        <script src="data.json" type="text/javascript" charset="utf-8"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js" type="text/javascript" charset="utf-8"></script>
+        <script src="https://cobismith.github.io/forestlaws/paper.js" type="text/javascript" charset="utf-8"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.1.7/underscore-min.js" type="text/javascript" charset="utf-8"></script>
+        <script src="https://cobismith.github.io/forestlaws/data.json" type="text/javascript" charset="utf-8"></script>
         
-        <script type="text/paperscript" canvas="canvas" src="recycle.js"></script>
+        <script type="text/paperscript" canvas="canvas" src="https://cobismith.github.io/forestlaws/recycle.js"></script>
         
         <script type="text/javascript">
             jQuery(document).ready(function() {
@@ -20,9 +20,6 @@
             });
         </script>
         
-        <script type="text/javascript" src="//use.typekit.net/ran8aft.js"></script>
-<script type="text/javascript">try{Typekit.load();}catch(e){}</script>
-        
         <script type="text/javascript">
             var _gaq = _gaq || [];
             _gaq.push(['_setAccount', 'UA-26336682-1']);
@@ -30,13 +27,13 @@
             
             (function() {
                 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'https://www') + '.google-analytics.com/ga.js';
                 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
             })();
         </script>
     </head> 
     <body>
-        <a href="https://github.com/cobismith/forestlaws" id="forkme"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
+        <a href="https://github.com/cobismith/forestlaws" id="forkme"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
   
         <h1>Infographic of REDD+ and related international laws</h1>
         


### PR DESCRIPTION
Resolves #1 

- [x] Update all resources to pull from `https`
- [x] Remove `use.typekit.net` as it doesn't appear to be used

This attempts to resolve loading https://cobismith.github.io/forestlaws/ over `https` by loading all resources over `https` also.

## Notes

`paper.js`, `recycle.js`, and `data.json` now point to github, so if making changes locally temporarily remove the `https://cobismith.github.io/forestlaws/` prefix.

e.g. To see any changes to `data.json` locally, change: `<script src="https://cobismith.github.io/forestlaws/data.json" type="text/javascript" charset="utf-8"></script>` to `<script src="data.json" type="text/javascript" charset="utf-8"></script>`